### PR TITLE
Some small visual tweaks

### DIFF
--- a/src/lib/components/HexGrid.svelte
+++ b/src/lib/components/HexGrid.svelte
@@ -171,7 +171,8 @@
     role='presentation'
     class='hex-grid'
     style='--hex-width: {hex_width}px; --grid-height: {grid_height}px; --top: {top}px; --bottom: {bottom}px;'>
-    {#each {length: num_rows * num_cols} as _, hex_index}
+    <!-- Tie the identity of each hexagon to the total number of columns, to force recreate them when the window size changes. -->
+    {#each {length: num_rows * num_cols} as _, hex_index (hex_index + '-' + num_cols)}
         {@const [x, y] = hex_origin(hex_index)}
         <Hexagon
             bind:this={hexagons[hex_index]}

--- a/src/lib/components/HexGrid.svelte
+++ b/src/lib/components/HexGrid.svelte
@@ -165,23 +165,26 @@
 
 <svelte:window bind:innerWidth />
 
-<div
-    bind:this={grid}
-    on:mousemove={on_move}
-    role='presentation'
-    class='hex-grid'
-    style='--hex-width: {hex_width}px; --grid-height: {grid_height}px; --top: {top}px; --bottom: {bottom}px;'>
-    <!-- Tie the identity of each hexagon to the total number of columns, to force recreate them when the window size changes. -->
-    {#each {length: num_rows * num_cols} as _, hex_index (hex_index + '-' + num_cols)}
-        {@const [x, y] = hex_origin(hex_index)}
-        <Hexagon
-            bind:this={hexagons[hex_index]}
-            width={hex_width}
-            {x}
-            {y}
-            {transition_speed} />
-    {/each}
-</div>
+<!-- Don't draw any hexagons if we don't yet know the window size. -->
+{#if innerWidth}
+    <div
+        bind:this={grid}
+        on:mousemove={on_move}
+        role='presentation'
+        class='hex-grid'
+        style='--hex-width: {hex_width}px; --grid-height: {grid_height}px; --top: {top}px; --bottom: {bottom}px;'>
+        <!-- Tie the identity of each hexagon to the total number of columns, to force recreate them when the window size changes. -->
+        {#each {length: num_rows * num_cols} as _, hex_index (hex_index + '-' + num_cols)}
+            {@const [x, y] = hex_origin(hex_index)}
+            <Hexagon
+                bind:this={hexagons[hex_index]}
+                width={hex_width}
+                {x}
+                {y}
+                {transition_speed} />
+        {/each}
+    </div>
+{/if}
 
 <style lang='scss'>
     .hex-grid {

--- a/src/lib/components/HexGrid.svelte
+++ b/src/lib/components/HexGrid.svelte
@@ -24,7 +24,7 @@
     const x_start: number = -hex_width / 2;
     const y_start: number = bottom === undefined? -3 * hex_width: hex_width;
 
-    let hexagons: SvelteComponent[] = [];
+    let hexagons: Hexagon[] = [];
     $: hexagons = hexagons.filter((hexagon) => hexagon !== null)  // When changing the screen, sometimes null hexagons are left over.
     let interval: number = 0;
 
@@ -48,10 +48,10 @@
         hexagons.forEach((hexagon, hex_index) => {
             const row_index: number = Math.floor(hex_index / num_cols);
             setTimeout(() => {
-                hexagon.raised = true;
+                hexagon.raised = 1;
             }, row_index * pulse_propagation_delay);
             setTimeout(() => {
-                hexagon.raised = false;
+                hexagon.raised = 0;
             }, row_index * pulse_propagation_delay + hex_sustain);
         })
     }
@@ -82,8 +82,8 @@
 
     function reset_hexagons(): void {
         // Set all hexagons to not be raised.
-        hexagons.forEach((_, hi, hexagons) => hexagons[hi].raised = false);
-        hexagons.forEach((_, hi, hexagons) => hexagons[hi].half_raised = false);
+        hexagons.forEach((hexagon) => hexagon.raised = 0);
+    }
     }
 </script>
 

--- a/src/lib/components/HexGrid.svelte
+++ b/src/lib/components/HexGrid.svelte
@@ -56,8 +56,10 @@
         })
     }
 
-    function raise_surrounding_hexagons(hex_index: number, raise_fraction: number = 0.2): void {
-        // Set all surrounding hexagons to be half raised.
+    function highlight_hexagon(hex_index: number, raise_fraction: number = 0.3): void {
+        // Raise a hexagon and partially raise its neighbours. 
+        hexagons[hex_index].raised = 1;
+
         let hex_indices_to_be_raised: number[] = [
             hex_index - num_cols,
             hex_index - 2 * num_cols,
@@ -77,35 +79,106 @@
         }
         hex_indices_to_be_raised = hex_indices_to_be_raised.filter(x => x >= 0 && x < hexagons.length);
 
-        hex_indices_to_be_raised.forEach(index => hexagons[index].raised = 0.3);
+        hex_indices_to_be_raised.forEach(index => hexagons[index].raised = raise_fraction);
     }
 
     function reset_hexagons(): void {
         // Set all hexagons to not be raised.
         hexagons.forEach((hexagon) => hexagon.raised = 0);
     }
+
+    function hex_origin(hex_index: number): [number, number] {
+        const row_index = Math.floor(hex_index / num_cols);
+        const column_index = hex_index % num_cols;
+        const h_offset = (row_index % 2) / 2;
+        const x = x_start + (column_index + h_offset) * horizontal_distance;
+        const y = y_start + row_index * vertical_distance;
+        return [x, y];
+    }
+
+    function hex_index_at(x: number, y: number): number {
+        // See https://www.redblobgames.com/grids/hexagons/#rounding
+        function axial_round(q: number, r: number): [number, number] {
+            let q_round = Math.round(q);
+            let r_round = Math.round(r);
+            let s_round = Math.round(-q - r);
+
+            const q_diff = Math.abs(q_round - q);
+            const r_diff = Math.abs(r_round - r);
+            const s_diff = Math.abs(s_round - (-q - r));
+
+            if(q_diff > r_diff && q_diff > s_diff) {
+                q_round = -r_round - s_round;
+            } else if(r_diff > s_diff) {
+                r_round = -q_round - s_round;
+            } else {
+                s_round = -q_round - r_round;
+            }
+
+            return [q_round, r_round];
+        }
+        
+        const hex_width_incl_gap = hex_width + horizontal_gap / 3;
+        
+        // Find the center of the hexagon with index 0.
+        const x_zero_center = x_start + hex_width / 2;
+        const y_zero_center = y_start + hex_width * Math.sqrt(3) / 2;
+        
+        // Normalize the coordinates.
+        const x_normalized = (x - x_zero_center) / hex_width_incl_gap;
+        const y_normalized = (y - y_zero_center) / hex_width_incl_gap;
+        
+        // Find the axial coordinates according to https://www.redblobgames.com/grids/hexagons/#pixel-to-hex.
+        const q = x_normalized * 2 / 3;
+        const r = (-x_normalized / 3 + Math.sqrt(3) / 3 * y_normalized);
+        
+        // Round the axial coordinates to the nearest hexagon.
+        const [q_rounded, r_rounded] = axial_round(q, r);
+        
+        // Find the grid coordinates.
+        const col = Math.floor(q_rounded / 2);
+        const row = 2 * r_rounded + q_rounded;
+
+        return row * num_cols + col;
+    }
+
+    let grid: HTMLDivElement | null = null;
+
+    function on_move(event: MouseEvent): void {
+        if (!grid) {
+            return;
+        }
+
+        const bounds = grid.getBoundingClientRect();
+        const hex_index = hex_index_at(
+            event.clientX - bounds.left, 
+            event.clientY - bounds.top
+        );
+        
+        reset_hexagons();
+
+        if (hexagons[hex_index]) {
+            highlight_hexagon(hex_index);
+        }
     }
 </script>
 
 <svelte:window bind:innerWidth />
 
 <div
+    bind:this={grid}
+    on:mousemove={on_move}
+    role='presentation'
     class='hex-grid'
     style='--hex-width: {hex_width}px; --grid-height: {grid_height}px; --top: {top}px; --bottom: {bottom}px;'>
     {#each {length: num_rows * num_cols} as _, hex_index}
-        {@const row_index = Math.floor(hex_index / num_cols)}
-        {@const column_index = hex_index % num_cols}
-        {@const h_offset = (row_index % 2) / 2}
-        {@const x = x_start + (column_index + h_offset) * horizontal_distance}
-        {@const y = y_start + row_index * vertical_distance}
+        {@const [x, y] = hex_origin(hex_index)}
         <Hexagon
             bind:this={hexagons[hex_index]}
             width={hex_width}
             {x}
             {y}
-            {transition_speed}
-            on:mouseenter={() => raise_surrounding_hexagons(hex_index)}
-            on:mouseleave={reset_hexagons} />
+            {transition_speed} />
     {/each}
 </div>
 

--- a/src/lib/components/HexGrid.svelte
+++ b/src/lib/components/HexGrid.svelte
@@ -56,7 +56,7 @@
         })
     }
 
-    function highlight_hexagon(hex_index: number, raise_fraction: number = 0.3): void {
+    function highlight_hexagon(hex_index: number, neighbour_raise_fraction: number = 0.3): void {
         // Raise a hexagon and partially raise its neighbours. 
         hexagons[hex_index].raised = 1;
 
@@ -79,7 +79,7 @@
         }
         hex_indices_to_be_raised = hex_indices_to_be_raised.filter(x => x >= 0 && x < hexagons.length);
 
-        hex_indices_to_be_raised.forEach(index => hexagons[index].raised = raise_fraction);
+        hex_indices_to_be_raised.forEach(index => hexagons[index].raised = neighbour_raise_fraction);
     }
 
     function reset_hexagons(): void {

--- a/src/lib/components/Hexagon.svelte
+++ b/src/lib/components/Hexagon.svelte
@@ -3,7 +3,6 @@
 <svelte:options accessors />
 
 <script lang='ts'>
-    import { createEventDispatcher } from "svelte";
     import { dev_hexagon_pressed } from "../../routes/stores";
 
     // It's a bit ugly to set CSS strings via props, but I don't know a better way to propagate them.
@@ -16,23 +15,11 @@
     export let transition_speed: number = 600;
     export let raised: number = 0;
 
-    let dispatch = createEventDispatcher();
-
     const raise_translation: number = width / 4;
 
     $: z_index = raised? 1: 0 satisfies number;
     $: display_color = 'color-mix(in srgb, var(--color-button) ' + raised * 100 + '%, ' + color + ')' satisfies string;
     $: display_y = y - raise_translation * raised satisfies number;
-
-function enter_raise(): void {
-    raised = 1;
-    dispatch('mouseenter')
-}
-
-function leave_raise(): void {
-    raised = 0;
-    dispatch('mouseleave')
-}
 
     function handle_click(): void {
         // Activate a dev environment.
@@ -55,8 +42,6 @@ function leave_raise(): void {
         --z-index: {z_index};
         --transition-speed: {transition_speed}ms;
         --raise-translation: {raise_translation * raised}px;'
-    on:mouseenter={enter_raise}
-    on:mouseleave={leave_raise}
     on:focus
     on:click={handle_click}
     role='presentation'

--- a/src/lib/components/TextScroll.svelte
+++ b/src/lib/components/TextScroll.svelte
@@ -9,11 +9,23 @@
 
     let index = 0;
 
+    // Used to reset the component after each full rotation, without a transition.
+    let key = false;
+
     let interval: NodeJS.Timer;
 
     onMount(() => {
         interval = setInterval(() => {
-            index = (index + 1) % strings.length;
+            index += 1;
+
+            // If we have reached the end, reset the component in between animations.
+            // We only wrap around after `strings.length` is reached because the first string is duplicated at the end.
+            if (index === strings.length) {
+                setTimeout(() => {
+                    key = !key;
+                    index = 0;
+                }, 1000);
+            }
         }, animation_speed);
     });
 
@@ -22,14 +34,16 @@
     });
 </script>
 
-<span class='change-container'>
-    {longest_string}
-    {#each strings as text, ti}
-        <span class='text-container' style={`top: calc(100% * (${ti} - ${index}));`}>
-            {text}
-        </span>
-    {/each}
-</span>
+{#key key}
+    <span class='change-container'>
+        {longest_string}
+        {#each [...strings, strings[0]] as text, ti} <!-- Duplicate the first element at the end. -->
+            <span class='text-container' style={`top: calc(100% * (${ti} - ${index}));`}>
+                {text}
+            </span>
+        {/each}
+    </span>
+{/key}
 <!-- A little insurance in case JavaScript is disabled for whatever reason. -->
 <noscript>
     and more!

--- a/src/lib/components/TextScroll.svelte
+++ b/src/lib/components/TextScroll.svelte
@@ -2,7 +2,7 @@
     import { onDestroy, onMount } from 'svelte';
 
     export let strings: [string, ...string[]];
-    export let animation_speed: number = 2000;
+    export let animation_period: number = 2000;
 
     // Not necessarily the widest string, but it will do for now.
     $: longest_string = strings.reduce((a, b) => a.length > b.length? a: b) satisfies string;
@@ -24,9 +24,9 @@
                 setTimeout(() => {
                     key = !key;
                     index = 0;
-                }, 1000);
+                }, animation_period / 2);
             }
-        }, animation_speed);
+        }, animation_period);
     });
 
     onDestroy(() => {


### PR DESCRIPTION
- Avoid a visual glitch when putting the cursor right between two hexagons by letting `HexGrid` decide which hexagon to highlight.
- Prevent only some hexagons from showing while the page is loading.
- Prevent hexagons from jumping around when resizing the window or when loading the page.
- Make the `TextScroll` component always animate in the same direction.